### PR TITLE
Added root grouping of ZOO_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex; \
     addgroup sudo; \
     adduser -h $ZOO_HOME -g "Zookeeper user" -s /sbin/nologin -D -G $ZOO_GROUP -G sudo $ZOO_USER; \
     chown -R $ZOO_USER:$ZOO_GROUP $ZOO_HOME; \
+    chgrp -R 0 $ZOO_HOME; \
+    chmod -R g+rwX $ZOO_HOME; \
     ln -s $ZOO_HOME/bin/zk_*.sh /usr/bin
 
 USER $ZOO_USER


### PR DESCRIPTION
* This is an attempt to fix the error that occurs when running a zookeeper image in openshift: Permission denied for /opt/zookeer/data
* According to this reference: https://docs.openshift.com/enterprise/3.2/creating_images/guidelines.html
* Section: Support Arbitrary User IDs